### PR TITLE
Added a high extension start-priority.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>com.hivemq.extension</groupId>
     <artifactId>hivemq-etcd-cluster-discovery-extension</artifactId>
     <description>HiveMQ Extension for cluster discovery with etcd</description>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
 
     <properties>
         <extension.name>Etcd Cluster Discovery Extension</extension.name>

--- a/src/main/resources/hivemq-extension.xml
+++ b/src/main/resources/hivemq-extension.xml
@@ -17,5 +17,6 @@
     <name>${extension.name}</name>
     <version>${version}</version>
     <priority>1000</priority>
+    <start-priority>10000</start-priority>
     <author>MaibornWolff GmbH</author>
 </hivemq-extension>


### PR DESCRIPTION
With HiveMQ 4.3.2 comes a small improvement in the way extensions are loaded: the extension `start-priority`.

Cluster discovery extensions should have a higher value then the default.